### PR TITLE
Closes #2:  Automatically pull in data-private updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "data-private"]
-	path = data-private
+[submodule "_data/private"]
+	path = _data/private
 	url = git@github.com:18F/data-private.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "_data/private"]
-	path = _data/private
-	url = git@github.com:18F/data-private.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data-private"]
+	path = data-private
+	url = git@github.com:18F/data-private.git

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Team API server, and illustrates each of the following settings:
   the team-api.18f.gov repo
 * **updatePort**: the port on which the server will listen for updates to
   `.about.yml` files from other 18F repos
+* **dataPort**: the port on which the server will listen for `push` events to
+  the data-private repo
 * **git**:  path to `git` on the host machine
 * **ruby**: path to `ruby` on the host machine
 * **workingDir**: path to the 18F/team-api.18f.gov repository clone on the

--- a/index.js
+++ b/index.js
@@ -25,7 +25,13 @@ module.exports.launchServer = function(config) {
     updater.checkForAndImportUpdates(info);
   }).listen(config.updatePort);
 
-  console.log('18F Team API: Listening on port ' + config.buildPort +
-    ' for push events on ' + config.branch + ' and port ' + config.updatePort +
-    ' for .about.yml updates.');
+  hookshot('push', function(info) {
+    var updater = new ProjectDataUpdater(config, info.repository, lock);
+    updater.updateDataPrivate(info);
+  }).listen(config.dataPort);
+
+  console.log('18F Team API - Listening on the following ports:\n' +
+    config.buildPort + ' for push events on ' + config.branch + '\n' +
+    config.updatePort + ' for .about.yml updates\n' +
+    config.updatePort + ' for data-private updates');
 };

--- a/index.js
+++ b/index.js
@@ -33,5 +33,5 @@ module.exports.launchServer = function(config) {
   console.log('18F Team API - Listening on the following ports:\n' +
     config.buildPort + ' for push events on ' + config.branch + '\n' +
     config.updatePort + ' for .about.yml updates\n' +
-    config.updatePort + ' for data-private updates');
+    config.dataPort + ' for data-private updates');
 };

--- a/lib/project-data-updater.js
+++ b/lib/project-data-updater.js
@@ -67,13 +67,12 @@ function ProjectDataUpdater(config, repository, updateLock, done) {
   };
 }
 
-ProjectDataUpdater.prototype.spawn = function(actionDescription, path, args, workingDir) {
+ProjectDataUpdater.prototype.spawn = function(actionDescription, path, args) {
   var that = this;
   var repoName = this.fullName;
-  var workingDir = workingDir || that.workingDir;
 
   return new Promise(function(resolve, reject) {
-    var opts = {cwd: workingDir, stdio: 'inherit'};
+    var opts = {cwd: that.workingDir, stdio: 'inherit'};
 
     childProcess.spawn(path, args, opts).on('close', function(exitStatus) {
       if (exitStatus !== 0) {

--- a/lib/project-data-updater.js
+++ b/lib/project-data-updater.js
@@ -43,7 +43,6 @@ function ProjectDataUpdater(config, repository, updateLock, done) {
   var that = this;
 
   this.workingDir = config.workingDir;
-  this.privateDataDir = config.privateDataDir;
   this.git = config.git;
   this.ruby = config.ruby;
 
@@ -98,8 +97,7 @@ ProjectDataUpdater.prototype.checkForAndImportUpdates = function(info) {
   if (module.exports.isValidUpdate(info) &&
     module.exports.fileUpdated(info.commits)) {
     this._doLockedOperation(function(done) {
-      that.pullDataPrivateChanges()
-        .then(function() { return that.pullChanges(); })
+      that.pullChanges()
         .then(function() { return that.importUpdates(); })
         .then(function() { return that.buildSite(); })
         .then(function() { return that.addUpdates(); })
@@ -122,9 +120,18 @@ ProjectDataUpdater.prototype.pullChangesAndRebuild = function() {
   });
 };
 
-ProjectDataUpdater.prototype.pullDataPrivateChanges = function() {
-  return this.spawn('pull changes', this.git, ['pull'], this.privateDataDir);
-};
+ProjectDataUpdater.prototype.updateDataPrivate = function() {
+  var that = this;
+
+  this._doLockedOperation(function(done) {
+    that.pullChanges()
+      .then(function() { return that.updateSubmodules(); })
+      .then(function() { return that.addUpdates(); })
+      .then(function() { return that.commitDataPrivateUpdates(); })
+      .then(function() { return that.pushUpdates(); })
+      .then(done, done);
+  });
+}
 
 ProjectDataUpdater.prototype.pullChanges = function() {
   return this.spawn('pull changes', this.git, ['pull']);
@@ -135,6 +142,10 @@ ProjectDataUpdater.prototype.importUpdates = function() {
     [this.updateScript, this.fullName, this.scope, this.defaultBranch]);
 };
 
+ProjectDataUpdater.prototype.updateSubmodules = function() {
+  return this.spawn('update submodules', this.git, ['submodule', 'update']);
+};
+
 ProjectDataUpdater.prototype.addUpdates = function() {
   return this.spawn('add updates', this.git, ['add' , '.']);
 };
@@ -143,6 +154,12 @@ ProjectDataUpdater.prototype.commitUpdates = function() {
   return this.spawn('commit updates', this.git,
     ['commit', '-m',
      module.exports.ABOUT_YML + ' import from ' + this.fullName]);
+};
+
+ProjectDataUpdater.prototype.commitDataPrivateUpdates = function() {
+  return this.spawn('commit updates', this.git,
+    ['commit', '-m',
+     'Updates from ' + this.fullName]);
 };
 
 ProjectDataUpdater.prototype.pushUpdates = function() {

--- a/lib/project-data-updater.js
+++ b/lib/project-data-updater.js
@@ -8,41 +8,54 @@ module.exports = ProjectDataUpdater;
 module.exports.ABOUT_YML = '.about.yml';
 
 module.exports.isValidUpdate = function(info) {
-  if (info.ref === undefined) { return false; }
-  var fullName;
-  var defaultBranch;
+  var defaultBranch,
+      fullName;
+
+  if (info.ref === undefined) {
+    return false;
+  }
+
   /* jshint ignore: start */
   fullName = info.repository.full_name;
   defaultBranch = info.repository.default_branch;
   /* jshint ignore: end */
+
   return fullName.indexOf('18F/', 0) === 0 &&
     info.ref === 'refs/heads/' + defaultBranch;
 };
 
 module.exports.fileUpdated = function(commits) {
+  var commit;
+
   for (var i = 0; i != commits.length; i++) {
-    var commit = commits[i];
+    commit = commits[i];
+
     if ((commit.added.indexOf(module.exports.ABOUT_YML) !== -1) ||
       (commit.modified.indexOf(module.exports.ABOUT_YML) !== -1)) {
       return true;
     }
   }
+
   return false;
 };
 
 function ProjectDataUpdater(config, repository, updateLock, done) {
+  var that = this;
+
   this.workingDir = config.workingDir;
+  this.privateDataDir = config.privateDataDir;
   this.git = config.git;
   this.ruby = config.ruby;
+
   /* jshint ignore:start */
   this.fullName = repository.full_name;
   this.defaultBranch = repository.default_branch;
   /* jshint ignore:end */
+
   this.scope = repository.private ? 'private' : 'public';
   this.lock = updateLock;
   this.updateScript = config.updateScript;
 
-  var that = this;
   this.done = done || function(err) {
     if (err) {
       if (err.message) {
@@ -55,11 +68,14 @@ function ProjectDataUpdater(config, repository, updateLock, done) {
   };
 }
 
-ProjectDataUpdater.prototype.spawn = function(actionDescription, path, args) {
+ProjectDataUpdater.prototype.spawn = function(actionDescription, path, args, workingDir) {
   var that = this;
   var repoName = this.fullName;
+  var workingDir = workingDir || that.workingDir;
+
   return new Promise(function(resolve, reject) {
-    var opts = {cwd: that.workingDir, stdio: 'inherit'};
+    var opts = {cwd: workingDir, stdio: 'inherit'};
+
     childProcess.spawn(path, args, opts).on('close', function(exitStatus) {
       if (exitStatus !== 0) {
         reject(new Error(repoName + ': failed to ' + actionDescription));
@@ -75,13 +91,15 @@ ProjectDataUpdater.prototype._doLockedOperation = function(operation) {
 };
 
 ProjectDataUpdater.prototype.checkForAndImportUpdates = function(info) {
+  var that = this;
+
   // Longer-term: Determine if it most recently appears in commits.removed,
   // whether that means we should delete the project file.
   if (module.exports.isValidUpdate(info) &&
     module.exports.fileUpdated(info.commits)) {
-    var that = this;
     this._doLockedOperation(function(done) {
-      that.pullChanges()
+      that.pullDataPrivateChanges()
+        .then(function() { return that.pullChanges(); })
         .then(function() { return that.importUpdates(); })
         .then(function() { return that.buildSite(); })
         .then(function() { return that.addUpdates(); })
@@ -96,11 +114,16 @@ ProjectDataUpdater.prototype.checkForAndImportUpdates = function(info) {
 
 ProjectDataUpdater.prototype.pullChangesAndRebuild = function() {
   var that = this;
+
   this._doLockedOperation(function(done) {
     that.pullChanges()
       .then(function() { return that.buildSite(); })
       .then(done, done);
   });
+};
+
+ProjectDataUpdater.prototype.pullDataPrivateChanges = function() {
+  return this.spawn('pull changes', this.git, ['pull'], this.privateDataDir);
 };
 
 ProjectDataUpdater.prototype.pullChanges = function() {

--- a/lib/project-data-updater.js
+++ b/lib/project-data-updater.js
@@ -143,7 +143,8 @@ ProjectDataUpdater.prototype.importUpdates = function() {
 };
 
 ProjectDataUpdater.prototype.updateSubmodules = function() {
-  return this.spawn('update submodules', this.git, ['submodule', 'update']);
+  return this.spawn('update submodules', this.git,
+   ['submodule', 'update', '--remote']);
 };
 
 ProjectDataUpdater.prototype.addUpdates = function() {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "mocha": "^2.2.5",
     "mock-spawn": "^0.2.6"
   },
+  "scripts": {
+    "test": "gulp test"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/18F/team-api.git"

--- a/team-api-config.json
+++ b/team-api-config.json
@@ -2,9 +2,9 @@
   "branch": "master",
   "buildPort": 6000,
   "updatePort": 6001,
+  "dataPort": 6002,
   "git": "/usr/local/bin/hub",
   "ruby": "/Users/carlocostino/.rvm/rubies/ruby-2.2.3/bin/ruby",
-  "privateDataDir": "/Users/carlocostino/Projects/data-private",
   "workingDir": "/Users/carlocostino/Projects/team-api.18f.gov",
   "updateScript": "/Users/carlocostino/Projects/team-api.18f.gov/scripts/projects/update_project_from_about_yml.rb"
 }

--- a/team-api-config.json
+++ b/team-api-config.json
@@ -1,10 +1,10 @@
 {
-  "branch": "master",
-  "buildPort": 6000,
-  "updatePort": 6001,
-  "dataPort": 6002,
-  "git": "/usr/local/bin/hub",
-  "ruby": "/Users/carlocostino/.rvm/rubies/ruby-2.2.3/bin/ruby",
-  "workingDir": "/Users/carlocostino/Projects/team-api.18f.gov",
-  "updateScript": "/Users/carlocostino/Projects/team-api.18f.gov/scripts/projects/update_project_from_about_yml.rb"
+  "branch":       "master",
+  "buildPort":    6000,
+  "updatePort":   6001,
+  "dataPort":     6002,
+  "git":          "/usr/bin/git",
+  "ruby":         "/usr/local/rbenv/shims/ruby",
+  "workingDir":   "/home/ubuntu/team-api/",
+  "updateScript": "/home/ubuntu/team-api/scripts/projects/update_project_from_about_yml.rb"
 }

--- a/team-api-config.json
+++ b/team-api-config.json
@@ -1,9 +1,10 @@
 {
-  "branch":       "master",
-  "buildPort":    6000,
-  "updatePort":   6001,
-  "git":          "/usr/bin/git",
-  "ruby":         "/usr/local/rbenv/shims/ruby",
-  "workingDir":   "/home/ubuntu/team-api/",
-  "updateScript": "/home/ubuntu/team-api/scripts/projects/update_project_from_about_yml.rb"
+  "branch": "master",
+  "buildPort": 6000,
+  "updatePort": 6001,
+  "git": "/usr/local/bin/hub",
+  "ruby": "/Users/carlocostino/.rvm/rubies/ruby-2.2.3/bin/ruby",
+  "privateDataDir": "/Users/carlocostino/Projects/data-private",
+  "workingDir": "/Users/carlocostino/Projects/team-api.18f.gov",
+  "updateScript": "/Users/carlocostino/Projects/team-api.18f.gov/scripts/projects/update_project_from_about_yml.rb"
 }

--- a/test/project-data-updater-test.js
+++ b/test/project-data-updater-test.js
@@ -214,6 +214,7 @@ describe('ProjectDataUpdater', function() {
         expect(err).to.be.undefined;
         expect(spawnCalls()).to.eql(
           ['/usr/bin/git pull',
+           '/usr/bin/git pull',
            ['/usr/bin/ruby', config.updateScript,
             repository.full_name, 'public',  // jshint ignore:line
             repository.default_branch].join(' '),  // jshint ignore:line
@@ -230,11 +231,12 @@ describe('ProjectDataUpdater', function() {
     it('should abort the process if a step fails', function(done) {
       mySpawn.sequence.add(mySpawn.simple(0));
       mySpawn.sequence.add(mySpawn.simple(0));
+      mySpawn.sequence.add(mySpawn.simple(0));
       mySpawn.sequence.add(mySpawn.simple(1));
 
       var updater = makeUpdater(function(err) {
         process.nextTick(check(done, function() {
-          expect(mySpawn.calls.length).to.equal(3);
+          expect(mySpawn.calls.length).to.equal(4);
           expect(err.message).to.equal('18F/team-api: failed to build site');
         }));
       });
@@ -247,13 +249,13 @@ describe('ProjectDataUpdater', function() {
 
       var checkCallsDoNotOverlap = checkN(2, done, function(err) {
         expect(err).to.be.undefined;
-        expect(mySpawn.calls.length).to.equal(12);
+        expect(mySpawn.calls.length).to.equal(14);
         var calls = spawnCalls();
 
         // Without a locking mechanism, every odd-numbered call will be equal
         // to the subsequent even-numbered call, rather than the first half of
         // calls equaling the second half.
-        expect(calls.slice(0, 6)).to.eql(calls.slice(6, 12));
+        expect(calls.slice(0, 7)).to.eql(calls.slice(7, 14));
       });
 
       makeUpdater(checkCallsDoNotOverlap)

--- a/test/project-data-updater-test.js
+++ b/test/project-data-updater-test.js
@@ -121,6 +121,19 @@ describe('ProjectDataUpdater', function() {
     });
   };
 
+  var abortIfFailureUpdater = function(errorMsg, done) {
+    mySpawn.sequence.add(mySpawn.simple(0));
+    mySpawn.sequence.add(mySpawn.simple(0));
+    mySpawn.sequence.add(mySpawn.simple(1));
+
+    return makeUpdater(function(err) {
+      process.nextTick(check(done, function() {
+        expect(mySpawn.calls.length).to.equal(3);
+        expect(err.message).to.equal(errorMsg);
+      }));
+    });
+  };
+
   describe('spawn', function() {
     it('should spawn the specified command', function() {
       var updater = makeUpdater();
@@ -228,16 +241,8 @@ describe('ProjectDataUpdater', function() {
     });
 
     it('should abort the process if a step fails', function(done) {
-      mySpawn.sequence.add(mySpawn.simple(0));
-      mySpawn.sequence.add(mySpawn.simple(0));
-      mySpawn.sequence.add(mySpawn.simple(1));
-
-      var updater = makeUpdater(function(err) {
-        process.nextTick(check(done, function() {
-          expect(mySpawn.calls.length).to.equal(3);
-          expect(err.message).to.equal('18F/team-api: failed to build site');
-        }));
-      });
+      var updater = abortIfFailureUpdater(
+        '18F/team-api: failed to build site', done);
 
       updater.checkForAndImportUpdates(validPayload());
     });
@@ -282,7 +287,7 @@ describe('ProjectDataUpdater', function() {
         expect(err).to.be.undefined;
         expect(spawnCalls()).to.eql(
           ['/usr/bin/git pull',
-           '/usr/bin/git submodule update',
+           '/usr/bin/git submodule update --remote',
            '/usr/bin/git add .',
            ['/usr/bin/git commit -m', 'Updates from',
            updater.fullName].join(' '),
@@ -293,16 +298,8 @@ describe('ProjectDataUpdater', function() {
     });
 
     it('should abort the process if a step fails', function(done) {
-      mySpawn.sequence.add(mySpawn.simple(0));
-      mySpawn.sequence.add(mySpawn.simple(0));
-      mySpawn.sequence.add(mySpawn.simple(1));
-
-      var updater = makeUpdater(function(err) {
-        process.nextTick(check(done, function() {
-          expect(mySpawn.calls.length).to.equal(3);
-          expect(err.message).to.equal('18F/team-api: failed to add updates');
-        }));
-      });
+      var updater = abortIfFailureUpdater(
+        '18F/team-api: failed to add updates', done);
 
       updater.updateDataPrivate();
     });


### PR DESCRIPTION
This changeset adds support for pulling in updates from the data-private repo so that when we update the Team API site (team-api.18f.gov) we are retrieving the latest information.  This is important in the cases of when we have projects who do not have their own GitHub repo - the data-private repo is the only source to retrieve information about them.