### PR TITLE
[WIP] Convert this to an about.yml copier

### DIFF
--- a/lib/github-api-copy.js
+++ b/lib/github-api-copy.js
@@ -1,0 +1,113 @@
+/* jshint node: true */
+
+'use strict';
+
+var request = require('request');
+
+// https://developer.github.com/v3/repos/contents/#update-a-file
+
+var BASE_URL = 'https://api.github.com';
+
+var USER_AGENT = '18F';
+
+var AUTH = {
+  user: process.env.GITHUB_USERNAME,
+  pass: process.env.GITHUB_PASSWORD,
+  sendImmediately: true
+};
+
+function getFile(options, cb) {
+  var repo = options.repo;
+  var path = options.path;
+
+  request.get(BASE_URL + '/repos/' + repo + '/contents/' + path, {
+    auth: AUTH,
+    headers: {
+      'User-Agent': USER_AGENT
+    },
+    json: true
+  }, function(err, res, body) {
+    if (err)
+      return cb(err);
+
+    if (res.statusCode === 404) {
+      return cb(null, null);
+    }
+
+    if (res.statusCode === 200) {
+      return cb(null, body);
+    }
+
+    return cb(new Error("Got HTTP " + res.statusCode));
+  });
+}
+
+function putFile(options, cb) {
+  var repo = options.repo;
+  var path = options.path;
+  var content = options.content;
+  var sha = options.sha;
+
+  request.put(BASE_URL + '/repos/' + repo + '/contents/' + path, {
+    auth: AUTH,
+    headers: {
+      'User-Agent': USER_AGENT
+    },
+    json: {
+      message: "automated commit!",
+      content: new Buffer(content).toString('base64'),
+      sha: sha
+    }
+  }, function(err, res, body) {
+    if (err)
+      return cb(err);
+
+    if (res.statusCode !== 200 && res.statusCode !== 201) {
+      console.log(body);
+      return cb(new Error("Got HTTP " + res.statusCode));
+    }
+
+    cb(null, body);
+  });
+}
+
+function createOrUpdateFile(options, cb) {
+  var repo = options.repo;
+  var path = options.path;
+  var content = options.content;
+  var sha;
+
+  getFile({
+    path: path,
+    repo: repo
+  }, function(err, body) {
+    if (err)
+      return cb(err);
+
+    if (body && body.sha) {
+      sha = body.sha;
+    }
+
+    putFile({
+      path: path,
+      repo: repo,
+      content: content,
+      sha: sha
+    }, cb);
+  });
+}
+
+if (!module.parent) {
+  // Manual testing code.
+
+  createOrUpdateFile({
+    path: '_data/projects/boop.yml',
+    repo: 'toolness/about-yml-testing',
+    content: 'Hello!'
+  }, function(err, body) {
+    if (err)
+      throw err;
+
+    console.log("SUCCESS", body);
+  });
+}

--- a/lib/github-file-client.js
+++ b/lib/github-file-client.js
@@ -51,11 +51,15 @@ GitHubFileClient.prototype.putFile = function(options) {
   var content = options.content;
   var sha = options.sha;
 
+  if (content instanceof Buffer) {
+    content = content.toString('base64')
+  }
+
   return new Promise(function(resolve, reject) {
     this.request.put(BASE_URL + '/repos/' + repo + '/contents/' + path, {
       json: {
         message: "automated commit!",
-        content: new Buffer(content).toString('base64'),
+        content: content,
         sha: sha
       }
     }, function(err, res, body) {
@@ -92,13 +96,39 @@ GitHubFileClient.prototype.createOrUpdateFile = function(options) {
   }.bind(this));
 }
 
+GitHubFileClient.prototype.copyFile = function(options) {
+  var source = options.source;
+  var dest = options.dest;
+
+  return this.getFile(source.repo, source.path).then(function(body) {
+    if (!(body && typeof(body.content) === 'string')) {
+      return Promise.reject(new Error('Source is not a file'));
+    }
+
+    if (body.encoding !== 'base64') {
+      return Promise.reject(new Error('Source is not base64-encoded'));
+    }
+
+    return this.createOrUpdateFile({
+      repo: dest.repo,
+      path: dest.path,
+      content: body.content
+    });
+  }.bind(this));
+}
+
 if (!module.parent) {
   // Manual testing code.
 
-  new GitHubFileClient().createOrUpdateFile({
-    path: '_data/projects/boop.yml',
-    repo: 'toolness/about-yml-testing',
-    content: 'Hello!'
+  new GitHubFileClient().copyFile({
+    source: {
+      path: '.about.yml',
+      repo: process.env.GITHUB_USERNAME + '/about-yml-testing-sample-project'
+    },
+    dest: {
+      path: '_data/projects/about-yml-testing-sample-project.yml',
+      repo: process.env.GITHUB_USERNAME + '/about-yml-testing'
+    }
   }).then(function(body) {
     console.log("SUCCESS");
   }).catch(function(e) {

--- a/lib/github-file-client.js
+++ b/lib/github-file-client.js
@@ -18,7 +18,8 @@ function GitHubFileClient(user, pass) {
       sendImmediately: true
     },
     headers: {
-      'User-Agent': USER_AGENT
+      'User-Agent': USER_AGENT,
+      'Accept': 'application/vnd.github.v3+json'
     }
   });
 }

--- a/lib/github-file-client.js
+++ b/lib/github-file-client.js
@@ -49,6 +49,7 @@ GitHubFileClient.prototype.putFile = function(options) {
   var repo = options.repo;
   var path = options.path;
   var content = options.content;
+  var message = options.message || "Automated commit from " + USER_AGENT;
   var sha = options.sha;
 
   if (content instanceof Buffer) {
@@ -58,7 +59,7 @@ GitHubFileClient.prototype.putFile = function(options) {
   return new Promise(function(resolve, reject) {
     this.request.put(BASE_URL + '/repos/' + repo + '/contents/' + path, {
       json: {
-        message: "automated commit!",
+        message: message,
         content: content,
         sha: sha
       }
@@ -80,6 +81,7 @@ GitHubFileClient.prototype.createOrUpdateFile = function(options) {
   var repo = options.repo;
   var path = options.path;
   var content = options.content;
+  var message = options.message;
   var sha;
 
   return this.getFile(repo, path).then(function(body) {
@@ -91,6 +93,7 @@ GitHubFileClient.prototype.createOrUpdateFile = function(options) {
       path: path,
       repo: repo,
       content: content,
+      message: message,
       sha: sha
     });
   }.bind(this));
@@ -99,6 +102,7 @@ GitHubFileClient.prototype.createOrUpdateFile = function(options) {
 GitHubFileClient.prototype.copyFile = function(options) {
   var source = options.source;
   var dest = options.dest;
+  var message = options.message;
 
   return this.getFile(source.repo, source.path).then(function(body) {
     if (!(body && typeof(body.content) === 'string')) {
@@ -112,6 +116,7 @@ GitHubFileClient.prototype.copyFile = function(options) {
     return this.createOrUpdateFile({
       repo: dest.repo,
       path: dest.path,
+      message: message,
       content: body.content
     });
   }.bind(this));
@@ -128,7 +133,8 @@ if (!module.parent) {
     dest: {
       path: '_data/projects/about-yml-testing-sample-project.yml',
       repo: process.env.GITHUB_USERNAME + '/about-yml-testing'
-    }
+    },
+    message: 'Copied about-yml-testing-sample-project\'s .about.yml.'
   }).then(function(body) {
     console.log("SUCCESS");
   }).catch(function(e) {

--- a/lib/github-file-client.js
+++ b/lib/github-file-client.js
@@ -24,70 +24,71 @@ function GitHubFileClient(user, pass) {
   });
 }
 
-GitHubFileClient.prototype.getFile = function(repo, path, cb) {
-  this.request.get(BASE_URL + '/repos/' + repo + '/contents/' + path, {
-    json: true
-  }, function(err, res, body) {
-    if (err)
-      return cb(err);
+GitHubFileClient.prototype.getFile = function(repo, path) {
+  return new Promise(function(resolve, reject) {
+    this.request.get(BASE_URL + '/repos/' + repo + '/contents/' + path, {
+      json: true
+    }, function(err, res, body) {
+      if (err)
+        return reject(err);
 
-    if (res.statusCode === 404) {
-      return cb(null, null);
-    }
+      if (res.statusCode === 404) {
+        return resolve(null);
+      }
 
-    if (res.statusCode === 200) {
-      return cb(null, body);
-    }
+      if (res.statusCode === 200) {
+        return resolve(body);
+      }
 
-    return cb(new Error("Got HTTP " + res.statusCode));
-  });
+      return reject(new Error("Got HTTP " + res.statusCode));
+    });
+  }.bind(this));
 }
 
-GitHubFileClient.prototype.putFile = function(options, cb) {
+GitHubFileClient.prototype.putFile = function(options) {
   var repo = options.repo;
   var path = options.path;
   var content = options.content;
   var sha = options.sha;
 
-  this.request.put(BASE_URL + '/repos/' + repo + '/contents/' + path, {
-    json: {
-      message: "automated commit!",
-      content: new Buffer(content).toString('base64'),
-      sha: sha
-    }
-  }, function(err, res, body) {
-    if (err)
-      return cb(err);
+  return new Promise(function(resolve, reject) {
+    this.request.put(BASE_URL + '/repos/' + repo + '/contents/' + path, {
+      json: {
+        message: "automated commit!",
+        content: new Buffer(content).toString('base64'),
+        sha: sha
+      }
+    }, function(err, res, body) {
+      if (err)
+        return reject(err);
 
-    if (res.statusCode !== 200 && res.statusCode !== 201) {
-      console.log(body);
-      return cb(new Error("Got HTTP " + res.statusCode));
-    }
+      if (res.statusCode !== 200 && res.statusCode !== 201) {
+        console.log(body);
+        return reject(new Error("Got HTTP " + res.statusCode));
+      }
 
-    cb(null, body);
-  });
+      resolve(body);
+    });
+  }.bind(this));
 }
 
-GitHubFileClient.prototype.createOrUpdateFile = function(options, cb) {
+GitHubFileClient.prototype.createOrUpdateFile = function(options) {
   var repo = options.repo;
   var path = options.path;
   var content = options.content;
   var sha;
 
-  this.getFile(repo, path, function(err, body) {
-    if (err)
-      return cb(err);
-
+  return this.getFile(repo, path).then(function(body) {
     if (body && body.sha) {
       sha = body.sha;
     }
 
-    this.putFile({
+    return this.putFile({
       path: path,
       repo: repo,
       content: content,
       sha: sha
-    }, cb);
+    });
   }.bind(this));
 }
 
@@ -98,10 +99,9 @@ if (!module.parent) {
     path: '_data/projects/boop.yml',
     repo: 'toolness/about-yml-testing',
     content: 'Hello!'
-  }, function(err, body) {
-    if (err)
-      throw err;
-
+  }).then(function(body) {
     console.log("SUCCESS");
+  }).catch(function(e) {
+    console.log("ERROR", e);
   });
 }

--- a/lib/github-file-client.js
+++ b/lib/github-file-client.js
@@ -10,21 +10,21 @@ var BASE_URL = 'https://api.github.com';
 
 var USER_AGENT = '18F';
 
-var AUTH = {
-  user: process.env.GITHUB_USERNAME,
-  pass: process.env.GITHUB_PASSWORD,
-  sendImmediately: true
-};
-
-function getFile(options, cb) {
-  var repo = options.repo;
-  var path = options.path;
-
-  request.get(BASE_URL + '/repos/' + repo + '/contents/' + path, {
-    auth: AUTH,
+function GitHubFileClient(user, pass) {
+  this.request = request.defaults({
+    auth: {
+      user: user || process.env.GITHUB_USERNAME,
+      pass: pass || process.env.GITHUB_PASSWORD,
+      sendImmediately: true
+    },
     headers: {
       'User-Agent': USER_AGENT
-    },
+    }
+  });
+}
+
+GitHubFileClient.prototype.getFile = function(repo, path, cb) {
+  this.request.get(BASE_URL + '/repos/' + repo + '/contents/' + path, {
     json: true
   }, function(err, res, body) {
     if (err)
@@ -42,17 +42,13 @@ function getFile(options, cb) {
   });
 }
 
-function putFile(options, cb) {
+GitHubFileClient.prototype.putFile = function(options, cb) {
   var repo = options.repo;
   var path = options.path;
   var content = options.content;
   var sha = options.sha;
 
-  request.put(BASE_URL + '/repos/' + repo + '/contents/' + path, {
-    auth: AUTH,
-    headers: {
-      'User-Agent': USER_AGENT
-    },
+  this.request.put(BASE_URL + '/repos/' + repo + '/contents/' + path, {
     json: {
       message: "automated commit!",
       content: new Buffer(content).toString('base64'),
@@ -71,16 +67,13 @@ function putFile(options, cb) {
   });
 }
 
-function createOrUpdateFile(options, cb) {
+GitHubFileClient.prototype.createOrUpdateFile = function(options, cb) {
   var repo = options.repo;
   var path = options.path;
   var content = options.content;
   var sha;
 
-  getFile({
-    path: path,
-    repo: repo
-  }, function(err, body) {
+  this.getFile(repo, path, function(err, body) {
     if (err)
       return cb(err);
 
@@ -88,19 +81,19 @@ function createOrUpdateFile(options, cb) {
       sha = body.sha;
     }
 
-    putFile({
+    this.putFile({
       path: path,
       repo: repo,
       content: content,
       sha: sha
     }, cb);
-  });
+  }.bind(this));
 }
 
 if (!module.parent) {
   // Manual testing code.
 
-  createOrUpdateFile({
+  new GitHubFileClient().createOrUpdateFile({
     path: '_data/projects/boop.yml',
     repo: 'toolness/about-yml-testing',
     content: 'Hello!'
@@ -108,6 +101,6 @@ if (!module.parent) {
     if (err)
       throw err;
 
-    console.log("SUCCESS", body);
+    console.log("SUCCESS");
   });
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "file-locked-operation": "1.0.0",
     "hookshot": "18f/hookshot#0.1.0-with-json-options",
-    "lockfile": "^1.0.1"
+    "lockfile": "^1.0.1",
+    "request": "^2.72.0"
   }
 }


### PR DESCRIPTION
This is a foolhardy attempt to convert team-api-server into a much simpler tool that just waits for GitHub webhook notifications from other 18F repos and copies their `.about.yml`'s to `_data/projects/<project-name>.yml` in the [team-api.18f.gov](https://github.com/18F/team-api.18f.gov) repo using the GitHub API.

This means:

* No more serving static files built from team-api.18f.gov. We'll move that over to a [cloud.gov `staticfile-buildpack`](https://docs.cloud.gov/apps/static/), which will be pushed-to by a travis `after_success` hook on team-api.18f.gov.

* No more calling `git` from the command-line on the server-side. We'll use GitHub's API directly.

The above means that we remove ruby and git as dependencies, making this a pretty straightforward node app that can be deployed to cloud.gov via its [node buildpack](https://docs.cloud.gov/apps/node/).

### Setup

In order to use this, the following environment variables need to be defined:

* `GITHUB_USERNAME` - The GitHub user that will authenticate with the GitHub API.
* `GITHUB_PASSWORD` - The password used to authenticate with the GitHub API. Note that this should really be a [personal access token](https://github.com/blog/1509-personal-api-tokens) with [`repo` scope](https://developer.github.com/v3/oauth/#scopes).

### To do

- [X] `github-file-client.js` uses callbacks, but existing code in this project uses promises, so we should convert it to use promises too.
- [ ] Add tests for `github-file-client.js`.
- [ ] Change `project-data-updater.js` to just listen for webhooks from other repos and copy the `.about.yml`.
- [ ] Get rid of `team-api-config.json` and [store config in the environment](http://12factor.net/config) for easy cloud.gov deployment.
- [ ] It'd be nice, but not *necessary*, if the [`author`](https://developer.github.com/v3/repos/contents/#optional-parameters) of each copied file was the same as the author of the `.about.yml` change that triggered the webhook. Or if the commit message of the automated commit included a link to the commit that triggered the webhook. Anything to provide some context around causality.